### PR TITLE
feat: configurable programId + minor refactors

### DIFF
--- a/app/(app)/config/page.tsx
+++ b/app/(app)/config/page.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/components/ui/card";
 import { Connection, PublicKey, clusterApiUrl } from "@solana/web3.js";
 import * as multisig from "@sqds/multisig";
-import { headers } from "next/headers";
+import { cookies, headers } from "next/headers";
 const ConfigurationPage = async () => {
   const rpcUrl = headers().get("x-rpc-url");
 
@@ -19,8 +19,10 @@ const ConfigurationPage = async () => {
   const multisigCookie = headers().get("x-multisig");
   const multisigPda = new PublicKey(multisigCookie!);
   const vaultIndex = Number(headers().get("x-vault-index"));
-  const programIdCookie = headers().get("x-program-id");
-  const programId = new PublicKey(programIdCookie!);
+  const programIdCookie = cookies().get("x-programid")?.value;
+  const programId = programIdCookie
+    ? new PublicKey(programIdCookie!)
+    : multisig.PROGRAM_ID;
 
   const multisigInfo = await multisig.accounts.Multisig.fromAccountAddress(
     connection,
@@ -59,8 +61,8 @@ const ConfigurationPage = async () => {
                         Number(multisigInfo.transactionIndex) + 1
                       }
                       programId={
-                        programIdCookie
-                          ? programIdCookie
+                        programId.toBase58()
+                          ? programId.toBase58()
                           : multisig.PROGRAM_ID.toBase58()
                       }
                     />

--- a/app/(app)/config/page.tsx
+++ b/app/(app)/config/page.tsx
@@ -19,6 +19,8 @@ const ConfigurationPage = async () => {
   const multisigCookie = headers().get("x-multisig");
   const multisigPda = new PublicKey(multisigCookie!);
   const vaultIndex = Number(headers().get("x-vault-index"));
+  const programIdCookie = headers().get("x-program-id");
+  const programId = new PublicKey(programIdCookie!);
 
   const multisigInfo = await multisig.accounts.Multisig.fromAccountAddress(
     connection,
@@ -56,6 +58,11 @@ const ConfigurationPage = async () => {
                       transactionIndex={
                         Number(multisigInfo.transactionIndex) + 1
                       }
+                      programId={
+                        programIdCookie
+                          ? programIdCookie
+                          : multisig.PROGRAM_ID.toBase58()
+                      }
                     />
                   </div>
                 </div>
@@ -76,6 +83,11 @@ const ConfigurationPage = async () => {
               multisigPda={multisigCookie!}
               rpcUrl={rpcUrl || clusterApiUrl("mainnet-beta")}
               transactionIndex={Number(multisigInfo.transactionIndex) + 1}
+              programId={
+                programIdCookie
+                  ? programIdCookie
+                  : multisig.PROGRAM_ID.toBase58()
+              }
             />
           </CardContent>
         </Card>
@@ -91,6 +103,11 @@ const ConfigurationPage = async () => {
               multisigPda={multisigCookie!}
               rpcUrl={rpcUrl || clusterApiUrl("mainnet-beta")}
               transactionIndex={Number(multisigInfo.transactionIndex) + 1}
+              programId={
+                programIdCookie
+                  ? programIdCookie
+                  : multisig.PROGRAM_ID.toBase58()
+              }
             />
           </CardContent>
         </Card>
@@ -109,6 +126,11 @@ const ConfigurationPage = async () => {
               rpcUrl={rpcUrl || clusterApiUrl("mainnet-beta")}
               transactionIndex={Number(multisigInfo.transactionIndex) + 1}
               vaultIndex={vaultIndex}
+              globalProgramId={
+                programIdCookie
+                  ? programIdCookie
+                  : multisig.PROGRAM_ID.toBase58()
+              }
             />
           </CardContent>
         </Card>

--- a/app/(app)/config/page.tsx
+++ b/app/(app)/config/page.tsx
@@ -19,7 +19,7 @@ const ConfigurationPage = async () => {
   const multisigCookie = headers().get("x-multisig");
   const multisigPda = new PublicKey(multisigCookie!);
   const vaultIndex = Number(headers().get("x-vault-index"));
-  const programIdCookie = cookies().get("x-programid")?.value;
+  const programIdCookie = cookies().get("x-program-id")?.value;
   const programId = programIdCookie
     ? new PublicKey(programIdCookie!)
     : multisig.PROGRAM_ID;

--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -12,9 +12,12 @@ export default async function Home() {
   const multisigCookie = headers().get("x-multisig");
   const multisigPda = new PublicKey(multisigCookie!);
   const vaultIndex = Number(headers().get("x-vault-index"));
+  const programIdCookie = headers().get("x-program-id");
+  const programId = new PublicKey(programIdCookie!);
   const multisigVault = multisig.getVaultPda({
     multisigPda,
     index: vaultIndex || 0,
+    programId: programId ? programId : multisig.PROGRAM_ID,
   })[0];
 
   const tokensInWallet = await connection.getParsedTokenAccountsByOwner(
@@ -32,12 +35,14 @@ export default async function Home() {
         <VaultDisplayer
           multisigPdaString={multisigCookie!}
           vaultIndex={vaultIndex || 0}
+          programId={programIdCookie!}
         />
         <TokenList
           tokens={tokensInWallet}
           rpcUrl={rpcUrl!}
           multisigPda={multisigCookie!}
           vaultIndex={vaultIndex || 0}
+          programId={programIdCookie!}
         />
       </div>
     </main>

--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -1,3 +1,4 @@
+import SetProgramIdInput from "@/components/SetProgramIdInput";
 import SetRpcUrlInput from "@/components/SetRpcUrlnput";
 import {
   Card,
@@ -6,24 +7,34 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
 
 const SettingsPage = () => {
   return (
-    <div>
+    <main>
       <h1 className="text-3xl font-bold mb-4">Settings</h1>
-      <Card>
-        <CardHeader>
-          <CardTitle>RPC Url</CardTitle>
-          <CardDescription>
-            Change the default RPC Url for this app.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <SetRpcUrlInput />
-        </CardContent>
-      </Card>
-    </div>
+      <div className="flex-col space-y-4 justify-start">
+        <Card>
+          <CardHeader>
+            <CardTitle>RPC Url</CardTitle>
+            <CardDescription>
+              Change the default RPC Url for this app.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <SetRpcUrlInput />
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Program ID</CardTitle>
+            <CardDescription>Change the targeted program ID.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <SetProgramIdInput />
+          </CardContent>
+        </Card>
+      </div>
+    </main>
   );
 };
 

--- a/app/(app)/transactions/page.tsx
+++ b/app/(app)/transactions/page.tsx
@@ -17,7 +17,6 @@ import {
   PaginationNext,
   PaginationPrevious,
 } from "@/components/ui/pagination";
-import { Button } from "@/components/ui/button";
 import Link from "next/link";
 import ApproveButton from "@/components/ApproveButton";
 import ExecuteButton from "@/components/ExecuteButton";
@@ -37,6 +36,8 @@ export default async function TransactionsPage({
   const multisigCookie = headers().get("x-multisig");
   const multisigPda = new PublicKey(multisigCookie!);
   const vaultIndex = Number(headers().get("x-vault-index"));
+  const programIdCookie = headers().get("x-program-id");
+  const programId = new PublicKey(programIdCookie!);
 
   const multisigInfo = await multisig.accounts.Multisig.fromAccountAddress(
     connection,
@@ -64,10 +65,12 @@ export default async function TransactionsPage({
     const transactionPda = multisig.getTransactionPda({
       multisigPda,
       index,
+      programId: programId ? new PublicKey(programId) : multisig.PROGRAM_ID,
     });
     const proposalPda = multisig.getProposalPda({
       multisigPda,
       transactionIndex: index,
+      programId: programId ? new PublicKey(programId) : multisig.PROGRAM_ID,
     });
 
     let proposal;
@@ -125,6 +128,11 @@ export default async function TransactionsPage({
                     proposalStatus={
                       transaction.proposal?.status.__kind || "None"
                     }
+                    programId={
+                      programIdCookie
+                        ? programIdCookie
+                        : multisig.PROGRAM_ID.toBase58()
+                    }
                   />
                   <RejectButton
                     rpcUrl={rpcUrl!}
@@ -133,6 +141,11 @@ export default async function TransactionsPage({
                     proposalStatus={
                       transaction.proposal?.status.__kind || "None"
                     }
+                    programId={
+                      programIdCookie
+                        ? programIdCookie
+                        : multisig.PROGRAM_ID.toBase58()
+                    }
                   />
                   <ExecuteButton
                     rpcUrl={rpcUrl!}
@@ -140,6 +153,11 @@ export default async function TransactionsPage({
                     transactionIndex={transactionIndex}
                     proposalStatus={
                       transaction.proposal?.status.__kind || "None"
+                    }
+                    programId={
+                      programIdCookie
+                        ? programIdCookie
+                        : multisig.PROGRAM_ID.toBase58()
                     }
                   />
                 </TableCell>

--- a/components/AddMemberInput.tsx
+++ b/components/AddMemberInput.tsx
@@ -8,17 +8,20 @@ import { useWalletModal } from "@solana/wallet-adapter-react-ui";
 import * as multisig from "@sqds/multisig";
 import { Connection, PublicKey } from "@solana/web3.js";
 import { toast } from "sonner";
+import { isPublickey } from "@/lib/isPublickey";
 
 type AddMemberInputProps = {
   multisigPda: string;
   transactionIndex: number;
   rpcUrl: string;
+  programId: string;
 };
 
 const AddMemberInput = ({
   multisigPda,
   transactionIndex,
   rpcUrl,
+  programId,
 }: AddMemberInputProps) => {
   const [member, setMember] = useState("");
   const wallet = useWallet();
@@ -52,6 +55,7 @@ const AddMemberInput = ({
       rentPayer: wallet.publicKey,
       blockhash: (await connection.getLatestBlockhash()).blockhash,
       feePayer: wallet.publicKey,
+      programId: programId ? new PublicKey(programId) : multisig.PROGRAM_ID,
     });
 
     const signature = await wallet.sendTransaction(
@@ -75,7 +79,7 @@ const AddMemberInput = ({
         onChange={(e) => setMember(e.target.value)}
         className="mb-3"
       />
-      <Button onClick={addMember} disabled={!isValidPublicKey(member)}>
+      <Button onClick={addMember} disabled={!isPublickey(member)}>
         Add Member
       </Button>
     </div>
@@ -83,12 +87,3 @@ const AddMemberInput = ({
 };
 
 export default AddMemberInput;
-
-const isValidPublicKey = (value: string) => {
-  try {
-    new PublicKey(value);
-    return true;
-  } catch (e) {
-    return false;
-  }
-};

--- a/components/AddMemberInput.tsx
+++ b/components/AddMemberInput.tsx
@@ -6,7 +6,12 @@ import { useWallet } from "@solana/wallet-adapter-react";
 import { useState } from "react";
 import { useWalletModal } from "@solana/wallet-adapter-react-ui";
 import * as multisig from "@sqds/multisig";
-import { Connection, PublicKey } from "@solana/web3.js";
+import {
+  Connection,
+  PublicKey,
+  TransactionMessage,
+  VersionedTransaction,
+} from "@solana/web3.js";
 import { toast } from "sonner";
 import { isPublickey } from "@/lib/isPublickey";
 
@@ -37,7 +42,7 @@ const AddMemberInput = ({
       return;
     }
 
-    const addMemberTransaction = multisig.transactions.configTransactionCreate({
+    const addMemberIx = multisig.instructions.configTransactionCreate({
       multisigPda: new PublicKey(multisigPda),
       actions: [
         {
@@ -53,22 +58,39 @@ const AddMemberInput = ({
       creator: wallet.publicKey,
       transactionIndex: bigIntTransactionIndex,
       rentPayer: wallet.publicKey,
-      blockhash: (await connection.getLatestBlockhash()).blockhash,
-      feePayer: wallet.publicKey,
+      programId: programId ? new PublicKey(programId) : multisig.PROGRAM_ID,
+    });
+    const proposalIx = multisig.instructions.proposalCreate({
+      multisigPda: new PublicKey(multisigPda),
+      creator: wallet.publicKey,
+      isDraft: false,
+      transactionIndex: bigIntTransactionIndex,
+      rentPayer: wallet.publicKey,
+      programId: programId ? new PublicKey(programId) : multisig.PROGRAM_ID,
+    });
+    const approveIx = multisig.instructions.proposalApprove({
+      multisigPda: new PublicKey(multisigPda),
+      member: wallet.publicKey,
+      transactionIndex: bigIntTransactionIndex,
       programId: programId ? new PublicKey(programId) : multisig.PROGRAM_ID,
     });
 
-    const signature = await wallet.sendTransaction(
-      addMemberTransaction,
-      connection,
-      {
-        skipPreflight: true,
-      }
-    );
+    const message = new TransactionMessage({
+      instructions: [addMemberIx, proposalIx, approveIx],
+      payerKey: wallet.publicKey,
+      recentBlockhash: (await connection.getLatestBlockhash()).blockhash,
+    }).compileToV0Message();
+
+    const transaction = new VersionedTransaction(message);
+
+    const signature = await wallet.sendTransaction(transaction, connection, {
+      skipPreflight: true,
+    });
     console.log("Transaction signature", signature);
-    toast.info("Transaction submitted.");
+    toast.loading("Confirming...", {
+      id: "transaction",
+    });
     await connection.confirmTransaction(signature, "confirmed");
-    toast.success("Transaction created.");
     await new Promise((resolve) => setTimeout(resolve, 1000));
     router.refresh();
   };
@@ -79,7 +101,17 @@ const AddMemberInput = ({
         onChange={(e) => setMember(e.target.value)}
         className="mb-3"
       />
-      <Button onClick={addMember} disabled={!isPublickey(member)}>
+      <Button
+        onClick={() =>
+          toast.promise(addMember, {
+            id: "transaction",
+            loading: "Loading...",
+            success: "Add member action proposed.",
+            error: (e) => `Failed to propose: ${e}`,
+          })
+        }
+        disabled={!isPublickey(member)}
+      >
         Add Member
       </Button>
     </div>

--- a/components/ApproveButton.tsx
+++ b/components/ApproveButton.tsx
@@ -81,14 +81,26 @@ const ApproveButton = ({
       skipPreflight: true,
     });
     console.log("Transaction signature", signature);
-    toast.success("Approval submitted");
+    toast.loading("Confirming...", {
+      id: "transaction",
+    });
     await connection.confirmTransaction(signature, "confirmed");
-    toast.success("Proposal approved");
     await new Promise((resolve) => setTimeout(resolve, 1000));
     router.refresh();
   };
   return (
-    <Button disabled={isKindValid} onClick={approveProposal} className="mr-2">
+    <Button
+      disabled={isKindValid}
+      onClick={() =>
+        toast.promise(approveProposal, {
+          id: "transaction",
+          loading: "Loading...",
+          success: "Transaction approved.",
+          error: (e) => `Failed to approve: ${e}`,
+        })
+      }
+      className="mr-2"
+    >
       Approve
     </Button>
   );

--- a/components/ApproveButton.tsx
+++ b/components/ApproveButton.tsx
@@ -17,6 +17,7 @@ type ApproveButtonProps = {
   multisigPda: string;
   transactionIndex: number;
   proposalStatus: string;
+  programId: string;
 };
 
 const ApproveButton = ({
@@ -24,6 +25,7 @@ const ApproveButton = ({
   multisigPda,
   transactionIndex,
   proposalStatus,
+  programId,
 }: ApproveButtonProps) => {
   const wallet = useWallet();
   const walletModal = useWalletModal();
@@ -54,6 +56,7 @@ const ApproveButton = ({
         isDraft: false,
         transactionIndex: bigIntTransactionIndex,
         rentPayer: wallet.publicKey,
+        programId: programId ? new PublicKey(programId) : multisig.PROGRAM_ID,
       });
       transaction.add(createProposalInstruction);
     }
@@ -63,6 +66,7 @@ const ApproveButton = ({
           multisigPda: new PublicKey(multisigPda),
           member: wallet.publicKey,
           transactionIndex: bigIntTransactionIndex,
+          programId: programId ? new PublicKey(programId) : multisig.PROGRAM_ID,
         });
       transaction.add(activateProposalInstruction);
     }
@@ -70,6 +74,7 @@ const ApproveButton = ({
       multisigPda: new PublicKey(multisigPda),
       member: wallet.publicKey,
       transactionIndex: bigIntTransactionIndex,
+      programId: programId ? new PublicKey(programId) : multisig.PROGRAM_ID,
     });
     transaction.add(approveProposalInstruction);
     const signature = await wallet.sendTransaction(transaction, connection, {

--- a/components/ChangeThresholdInput.tsx
+++ b/components/ChangeThresholdInput.tsx
@@ -13,12 +13,14 @@ type ChangeThresholdInputProps = {
   multisigPda: string;
   transactionIndex: number;
   rpcUrl: string;
+  programId: string;
 };
 
 const ChangeThresholdInput = ({
   multisigPda,
   transactionIndex,
   rpcUrl,
+  programId,
 }: ChangeThresholdInputProps) => {
   const [threshold, setThreshold] = useState("");
   const wallet = useWallet();
@@ -48,6 +50,7 @@ const ChangeThresholdInput = ({
         rentPayer: wallet.publicKey,
         blockhash: (await connection.getLatestBlockhash()).blockhash,
         feePayer: wallet.publicKey,
+        programId: programId ? new PublicKey(programId) : multisig.PROGRAM_ID,
       });
 
     const signature = await wallet.sendTransaction(

--- a/components/ChangeUpgradeAuthorityInput.tsx
+++ b/components/ChangeUpgradeAuthorityInput.tsx
@@ -12,6 +12,7 @@ import {
   PublicKey,
   TransactionInstruction,
   TransactionMessage,
+  VersionedTransaction,
 } from "@solana/web3.js";
 import { toast } from "sonner";
 import { isPublickey } from "@/lib/isPublickey";
@@ -48,7 +49,7 @@ const ChangeUpgradeAuthorityInput = ({
       : multisig.PROGRAM_ID,
   })[0];
 
-  const changeThreshold = async () => {
+  const changeUpgradeAuth = async () => {
     if (!wallet.publicKey) {
       walletModal.setVisible(true);
       return;
@@ -97,12 +98,10 @@ const ChangeUpgradeAuthorityInput = ({
 
     const transactionIndexBN = BigInt(transactionIndex);
 
-    const multisigTransaction = multisig.transactions.vaultTransactionCreate({
+    const multisigTransactionIx = multisig.instructions.vaultTransactionCreate({
       multisigPda: new PublicKey(multisigPda),
-      blockhash,
       creator: wallet.publicKey,
       ephemeralSigners: 0,
-      feePayer: wallet.publicKey,
       transactionMessage,
       transactionIndex: transactionIndexBN,
       addressLookupTableAccounts: [],
@@ -112,18 +111,37 @@ const ChangeUpgradeAuthorityInput = ({
         ? new PublicKey(globalProgramId)
         : multisig.PROGRAM_ID,
     });
+    const proposalIx = multisig.instructions.proposalCreate({
+      multisigPda: new PublicKey(multisigPda),
+      creator: wallet.publicKey,
+      isDraft: false,
+      transactionIndex: bigIntTransactionIndex,
+      rentPayer: wallet.publicKey,
+      programId: programId ? new PublicKey(programId) : multisig.PROGRAM_ID,
+    });
+    const approveIx = multisig.instructions.proposalApprove({
+      multisigPda: new PublicKey(multisigPda),
+      member: wallet.publicKey,
+      transactionIndex: bigIntTransactionIndex,
+      programId: programId ? new PublicKey(programId) : multisig.PROGRAM_ID,
+    });
 
-    const signature = await wallet.sendTransaction(
-      multisigTransaction,
-      connection,
-      {
-        skipPreflight: true,
-      }
-    );
+    const message = new TransactionMessage({
+      instructions: [multisigTransactionIx, proposalIx, approveIx],
+      payerKey: wallet.publicKey,
+      recentBlockhash: (await connection.getLatestBlockhash()).blockhash,
+    }).compileToV0Message();
+
+    const transaction = new VersionedTransaction(message);
+
+    const signature = await wallet.sendTransaction(transaction, connection, {
+      skipPreflight: true,
+    });
     console.log("Transaction signature", signature);
-    toast.info("Transaction submitted.");
+    toast.loading("Confirming...", {
+      id: "transaction",
+    });
     await connection.confirmTransaction(signature, "confirmed");
-    toast.success("Transaction created.");
     await new Promise((resolve) => setTimeout(resolve, 1000));
     router.refresh();
   };
@@ -142,7 +160,14 @@ const ChangeUpgradeAuthorityInput = ({
         className="mb-3"
       />
       <Button
-        onClick={changeThreshold}
+        onClick={() =>
+          toast.promise(changeUpgradeAuth, {
+            id: "transaction",
+            loading: "Loading...",
+            success: "Upgrade authority change proposed.",
+            error: (e) => `Failed to propose: ${e}`,
+          })
+        }
         disabled={!isPublickey(programId) || !isPublickey(newAuthority)}
       >
         Change Authority

--- a/components/ChangeUpgradeAuthorityInput.tsx
+++ b/components/ChangeUpgradeAuthorityInput.tsx
@@ -14,12 +14,14 @@ import {
   TransactionMessage,
 } from "@solana/web3.js";
 import { toast } from "sonner";
+import { isPublickey } from "@/lib/isPublickey";
 
 type ChangeUpgradeAuthorityInputProps = {
   multisigPda: string;
   transactionIndex: number;
   rpcUrl: string;
   vaultIndex: number;
+  globalProgramId: string;
 };
 
 const ChangeUpgradeAuthorityInput = ({
@@ -27,6 +29,7 @@ const ChangeUpgradeAuthorityInput = ({
   transactionIndex,
   rpcUrl,
   vaultIndex,
+  globalProgramId,
 }: ChangeUpgradeAuthorityInputProps) => {
   const [programId, setProgramId] = useState("");
   const [newAuthority, setNewAuthority] = useState("");
@@ -40,6 +43,9 @@ const ChangeUpgradeAuthorityInput = ({
   const vaultAddress = multisig.getVaultPda({
     index: vaultIndex,
     multisigPda: new PublicKey(multisigPda),
+    programId: globalProgramId
+      ? new PublicKey(globalProgramId)
+      : multisig.PROGRAM_ID,
   })[0];
 
   const changeThreshold = async () => {
@@ -102,6 +108,9 @@ const ChangeUpgradeAuthorityInput = ({
       addressLookupTableAccounts: [],
       rentPayer: wallet.publicKey,
       vaultIndex: vaultIndex,
+      programId: globalProgramId
+        ? new PublicKey(globalProgramId)
+        : multisig.PROGRAM_ID,
     });
 
     const signature = await wallet.sendTransaction(
@@ -134,9 +143,7 @@ const ChangeUpgradeAuthorityInput = ({
       />
       <Button
         onClick={changeThreshold}
-        disabled={
-          !isValidPublicKey(programId) || !isValidPublicKey(newAuthority)
-        }
+        disabled={!isPublickey(programId) || !isPublickey(newAuthority)}
       >
         Change Authority
       </Button>
@@ -145,12 +152,3 @@ const ChangeUpgradeAuthorityInput = ({
 };
 
 export default ChangeUpgradeAuthorityInput;
-
-const isValidPublicKey = (value: string) => {
-  try {
-    new PublicKey(value);
-    return true;
-  } catch (e) {
-    return false;
-  }
-};

--- a/components/ExecuteButton.tsx
+++ b/components/ExecuteButton.tsx
@@ -24,6 +24,7 @@ type ExecuteButtonProps = {
   multisigPda: string;
   transactionIndex: number;
   proposalStatus: string;
+  programId: string;
 };
 
 const ExecuteButton = ({
@@ -31,6 +32,7 @@ const ExecuteButton = ({
   multisigPda,
   transactionIndex,
   proposalStatus,
+  programId,
 }: ExecuteButtonProps) => {
   const wallet = useWallet();
   const walletModal = useWalletModal();
@@ -62,6 +64,7 @@ const ExecuteButton = ({
         connection,
         member: wallet.publicKey,
         transactionIndex: bigIntTransactionIndex,
+        programId: programId ? new PublicKey(programId) : multisig.PROGRAM_ID,
       });
 
     const priorityFeeInstruction = ComputeBudgetProgram.setComputeUnitPrice({

--- a/components/ExecuteButton.tsx
+++ b/components/ExecuteButton.tsx
@@ -1,10 +1,12 @@
 "use client";
 import {
-  ComputeBudgetInstruction,
+  AddressLookupTableAccount,
   ComputeBudgetProgram,
   Connection,
   PublicKey,
-  Transaction,
+  TransactionInstruction,
+  TransactionMessage,
+  VersionedTransaction,
   clusterApiUrl,
 } from "@solana/web3.js";
 import { Button } from "./ui/button";
@@ -18,6 +20,11 @@ import { DialogTrigger } from "./ui/dialog";
 import { DialogContent, DialogTitle } from "./ui/dialog";
 import { useState } from "react";
 import { Input } from "./ui/input";
+
+type WithALT = {
+  instruction: TransactionInstruction;
+  lookupTableAccounts: AddressLookupTableAccount[];
+};
 
 type ExecuteButtonProps = {
   rpcUrl: string;
@@ -57,15 +64,67 @@ const ExecuteButton = ({
       return;
     }
 
-    let executeTransaction = new Transaction();
-    const executeInstruction =
-      await multisig.instructions.vaultTransactionExecute({
+    console.log({
+      multisigPda: multisigPda,
+      connection,
+      member: wallet.publicKey.toBase58(),
+      transactionIndex: bigIntTransactionIndex,
+      programId: programId ? programId : multisig.PROGRAM_ID.toBase58(),
+    });
+
+    const [transactionPda] = multisig.getTransactionPda({
+      multisigPda: new PublicKey(multisigPda),
+      index: bigIntTransactionIndex,
+      programId: programId ? new PublicKey(programId) : multisig.PROGRAM_ID,
+    });
+
+    let txType;
+    try {
+      await multisig.accounts.VaultTransaction.fromAccountAddress(
+        connection,
+        transactionPda
+      );
+      txType = "vault";
+    } catch (error) {
+      txType = await multisig.accounts.ConfigTransaction.fromAccountAddress(
+        connection,
+        transactionPda
+      );
+      txType = "config";
+    }
+    console.log(txType);
+
+    let executeInstruction;
+    let altAccounts;
+    if (txType == "vault") {
+      const resp = await multisig.instructions.vaultTransactionExecute({
         multisigPda: new PublicKey(multisigPda),
         connection,
         member: wallet.publicKey,
         transactionIndex: bigIntTransactionIndex,
         programId: programId ? new PublicKey(programId) : multisig.PROGRAM_ID,
       });
+      executeInstruction = resp.instruction;
+      altAccounts = resp.lookupTableAccounts;
+    } else if (txType == "config") {
+      executeInstruction = multisig.instructions.configTransactionExecute({
+        multisigPda: new PublicKey(multisigPda),
+        member: wallet.publicKey,
+        rentPayer: wallet.publicKey,
+        transactionIndex: bigIntTransactionIndex,
+        programId: programId ? new PublicKey(programId) : multisig.PROGRAM_ID,
+      });
+    } else {
+      const resp = await multisig.instructions.vaultTransactionExecute({
+        multisigPda: new PublicKey(multisigPda),
+        connection,
+        member: wallet.publicKey,
+        transactionIndex: bigIntTransactionIndex,
+        programId: programId ? new PublicKey(programId) : multisig.PROGRAM_ID,
+      });
+      executeInstruction = resp.instruction;
+      altAccounts = resp.lookupTableAccounts;
+    }
 
     const priorityFeeInstruction = ComputeBudgetProgram.setComputeUnitPrice({
       microLamports: priorityFeeLamports,
@@ -74,28 +133,28 @@ const ExecuteButton = ({
       units: computeUnitBudget,
     });
 
-    executeTransaction.add(
-      computeUnitInstruction,
-      priorityFeeInstruction,
-      executeInstruction.instruction
-    );
+    let blockhash = (await connection.getLatestBlockhash()).blockhash;
 
-    executeTransaction.recentBlockhash = (
-      await connection.getLatestBlockhash()
-    ).blockhash;
-    executeTransaction.feePayer = wallet.publicKey;
+    const executeMessage = new TransactionMessage({
+      instructions: [
+        priorityFeeInstruction,
+        computeUnitInstruction,
+        executeInstruction,
+      ],
+      payerKey: wallet.publicKey,
+      recentBlockhash: blockhash,
+    }).compileToV0Message(altAccounts && altAccounts);
 
-    const signature = await wallet.sendTransaction(
-      executeTransaction,
-      connection,
-      {
-        skipPreflight: true,
-      }
-    );
+    const execTx = new VersionedTransaction(executeMessage);
+
+    const signature = await wallet.sendTransaction(execTx, connection, {
+      skipPreflight: true,
+    });
     console.log("Transaction signature", signature);
-    toast.success("Transaction submitted.");
+    toast.loading("Confirming...", {
+      id: "transaction",
+    });
     await connection.confirmTransaction(signature, "confirmed");
-    toast.success("Transaction executed.");
     await new Promise((resolve) => setTimeout(resolve, 1000));
     router.refresh();
   };
@@ -129,7 +188,14 @@ const ExecuteButton = ({
         />
         <Button
           disabled={!isTransactionReady}
-          onClick={executeTransaction}
+          onClick={() =>
+            toast.promise(executeTransaction, {
+              id: "transaction",
+              loading: "Loading...",
+              success: "Transaction executed.",
+              error: "Failed to execute. Check console for info.",
+            })
+          }
           className="mr-2"
         >
           Execute

--- a/components/RejectButton.tsx
+++ b/components/RejectButton.tsx
@@ -85,16 +85,24 @@ const RejectButton = ({
       skipPreflight: true,
     });
     console.log("Transaction signature", signature);
-    toast.success("Transaction submitted.");
+    toast.loading("Confirming...", {
+      id: "transaction",
+    });
     await connection.confirmTransaction(signature, "confirmed");
-    toast.success("Transaction executed.");
     await new Promise((resolve) => setTimeout(resolve, 1000));
     router.refresh();
   };
   return (
     <Button
       disabled={!isKindValid}
-      onClick={rejectTransaction}
+      onClick={() =>
+        toast.promise(rejectTransaction, {
+          id: "transaction",
+          loading: "Loading...",
+          success: "Transaction rejected.",
+          error: (e) => `Failed to reject: ${e}`,
+        })
+      }
       className="mr-2"
     >
       Reject

--- a/components/RejectButton.tsx
+++ b/components/RejectButton.tsx
@@ -17,6 +17,7 @@ type RejectButtonProps = {
   multisigPda: string;
   transactionIndex: number;
   proposalStatus: string;
+  programId: string;
 };
 
 const RejectButton = ({
@@ -24,6 +25,7 @@ const RejectButton = ({
   multisigPda,
   transactionIndex,
   proposalStatus,
+  programId,
 }: RejectButtonProps) => {
   const wallet = useWallet();
   const walletModal = useWalletModal();
@@ -56,6 +58,7 @@ const RejectButton = ({
         isDraft: false,
         transactionIndex: bigIntTransactionIndex,
         rentPayer: wallet.publicKey,
+        programId: programId ? new PublicKey(programId) : multisig.PROGRAM_ID,
       });
       transaction.add(createProposalInstruction);
     }
@@ -65,6 +68,7 @@ const RejectButton = ({
           multisigPda: new PublicKey(multisigPda),
           member: wallet.publicKey,
           transactionIndex: bigIntTransactionIndex,
+          programId: programId ? new PublicKey(programId) : multisig.PROGRAM_ID,
         });
       transaction.add(activateProposalInstruction);
     }
@@ -72,6 +76,7 @@ const RejectButton = ({
       multisigPda: new PublicKey(multisigPda),
       member: wallet.publicKey,
       transactionIndex: bigIntTransactionIndex,
+      programId: programId ? new PublicKey(programId) : multisig.PROGRAM_ID,
     });
 
     transaction.add(rejectProposalInstruction);

--- a/components/RemoveMemberButton.tsx
+++ b/components/RemoveMemberButton.tsx
@@ -1,5 +1,10 @@
 "use client";
-import { Connection, PublicKey } from "@solana/web3.js";
+import {
+  Connection,
+  PublicKey,
+  TransactionMessage,
+  VersionedTransaction,
+} from "@solana/web3.js";
 import { Button } from "./ui/button";
 import * as multisig from "@sqds/multisig";
 import { useWallet } from "@solana/wallet-adapter-react";
@@ -37,39 +42,65 @@ const RemoveMemberButton = ({
     }
     let bigIntTransactionIndex = BigInt(transactionIndex);
 
-    const removeMemberTransaction =
-      multisig.transactions.configTransactionCreate({
-        multisigPda: new PublicKey(multisigPda),
-        actions: [
-          {
-            __kind: "RemoveMember",
-            oldMember: member,
-          },
-        ],
-        creator: wallet.publicKey,
-        transactionIndex: bigIntTransactionIndex,
-        rentPayer: wallet.publicKey,
-        blockhash: (await connection.getLatestBlockhash()).blockhash,
-        feePayer: wallet.publicKey,
-        programId: programId ? new PublicKey(programId) : multisig.PROGRAM_ID,
-      });
+    const removeMemberIx = multisig.instructions.configTransactionCreate({
+      multisigPda: new PublicKey(multisigPda),
+      actions: [
+        {
+          __kind: "RemoveMember",
+          oldMember: member,
+        },
+      ],
+      creator: wallet.publicKey,
+      transactionIndex: bigIntTransactionIndex,
+      rentPayer: wallet.publicKey,
+      programId: programId ? new PublicKey(programId) : multisig.PROGRAM_ID,
+    });
+    const proposalIx = multisig.instructions.proposalCreate({
+      multisigPda: new PublicKey(multisigPda),
+      creator: wallet.publicKey,
+      isDraft: false,
+      transactionIndex: bigIntTransactionIndex,
+      rentPayer: wallet.publicKey,
+      programId: programId ? new PublicKey(programId) : multisig.PROGRAM_ID,
+    });
+    const approveIx = multisig.instructions.proposalApprove({
+      multisigPda: new PublicKey(multisigPda),
+      member: wallet.publicKey,
+      transactionIndex: bigIntTransactionIndex,
+      programId: programId ? new PublicKey(programId) : multisig.PROGRAM_ID,
+    });
 
-    const signature = await wallet.sendTransaction(
-      removeMemberTransaction,
-      connection,
-      {
-        skipPreflight: true,
-      }
-    );
+    const message = new TransactionMessage({
+      instructions: [removeMemberIx, proposalIx, approveIx],
+      payerKey: wallet.publicKey,
+      recentBlockhash: (await connection.getLatestBlockhash()).blockhash,
+    }).compileToV0Message();
+
+    const transaction = new VersionedTransaction(message);
+
+    const signature = await wallet.sendTransaction(transaction, connection, {
+      skipPreflight: true,
+    });
     console.log("Transaction signature", signature);
-    toast.success("Transaction submitted.");
+    toast.loading("Confirming...", {
+      id: "transaction",
+    });
     await connection.confirmTransaction(signature, "confirmed");
-    toast.success("Transaction executed.");
     await new Promise((resolve) => setTimeout(resolve, 1000));
     router.refresh();
   };
   return (
-    <Button disabled={false} onClick={removeMember}>
+    <Button
+      disabled={false}
+      onClick={() =>
+        toast.promise(removeMember, {
+          id: "transaction",
+          loading: "Submitting...",
+          success: "Remove Member action proposed.",
+          error: (e) => `Failed to propose: ${e}`,
+        })
+      }
+    >
       Remove
     </Button>
   );

--- a/components/RemoveMemberButton.tsx
+++ b/components/RemoveMemberButton.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { Connection, PublicKey, Transaction } from "@solana/web3.js";
+import { Connection, PublicKey } from "@solana/web3.js";
 import { Button } from "./ui/button";
 import * as multisig from "@sqds/multisig";
 import { useWallet } from "@solana/wallet-adapter-react";
@@ -12,6 +12,7 @@ type RemoveMemberButtonProps = {
   multisigPda: string;
   transactionIndex: number;
   memberKey: string;
+  programId: string;
 };
 
 const RemoveMemberButton = ({
@@ -19,6 +20,7 @@ const RemoveMemberButton = ({
   multisigPda,
   transactionIndex,
   memberKey,
+  programId,
 }: RemoveMemberButtonProps) => {
   const wallet = useWallet();
   const walletModal = useWalletModal();
@@ -49,6 +51,7 @@ const RemoveMemberButton = ({
         rentPayer: wallet.publicKey,
         blockhash: (await connection.getLatestBlockhash()).blockhash,
         feePayer: wallet.publicKey,
+        programId: programId ? new PublicKey(programId) : multisig.PROGRAM_ID,
       });
 
     const signature = await wallet.sendTransaction(

--- a/components/SendTokensButton.tsx
+++ b/components/SendTokensButton.tsx
@@ -8,7 +8,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { Button } from "./ui/button";
-import { use, useEffect, useState } from "react";
+import { useState } from "react";
 import {
   createAssociatedTokenAccountIdempotentInstruction,
   createTransferCheckedInstruction,
@@ -19,7 +19,6 @@ import { useWallet } from "@solana/wallet-adapter-react";
 import {
   Connection,
   PublicKey,
-  Transaction,
   TransactionMessage,
   clusterApiUrl,
 } from "@solana/web3.js";
@@ -27,6 +26,7 @@ import { useWalletModal } from "@solana/wallet-adapter-react-ui";
 import { Input } from "./ui/input";
 import { toast } from "sonner";
 import { useRouter } from "next/navigation";
+import { isPublickey } from "@/lib/isPublickey";
 
 type SendTokensProps = {
   tokenAccount: string;
@@ -35,6 +35,7 @@ type SendTokensProps = {
   rpcUrl: string;
   multisigPda: string;
   vaultIndex: number;
+  programId?: string;
 };
 
 const SendTokens = ({
@@ -44,6 +45,7 @@ const SendTokens = ({
   rpcUrl,
   multisigPda,
   vaultIndex,
+  programId,
 }: SendTokensProps) => {
   const wallet = useWallet();
   const walletModal = useWalletModal();
@@ -66,6 +68,7 @@ const SendTokens = ({
       .getVaultPda({
         index: vaultIndex,
         multisigPda: new PublicKey(multisigPda),
+        programId: programId ? new PublicKey(programId) : multisig.PROGRAM_ID,
       })[0]
       .toBase58();
 
@@ -150,7 +153,7 @@ const SendTokens = ({
           type="text"
           onChange={(e) => setRecipient(e.target.value)}
         />
-        {isValidPublicKey(recipient) ? null : (
+        {isPublickey(recipient) ? null : (
           <p className="text-xs">Invalid recipient address</p>
         )}
         <Input
@@ -158,7 +161,7 @@ const SendTokens = ({
           type="number"
           onChange={(e) => setAmount(parseInt(e.target.value))}
         />
-        <Button onClick={transfer} disabled={!isValidPublicKey(recipient)}>
+        <Button onClick={transfer} disabled={!isPublickey(recipient)}>
           Transfer
         </Button>
       </DialogContent>
@@ -167,12 +170,3 @@ const SendTokens = ({
 };
 
 export default SendTokens;
-
-const isValidPublicKey = (value: string) => {
-  try {
-    new PublicKey(value);
-    return true;
-  } catch (e) {
-    return false;
-  }
-};

--- a/components/SetProgramIdInput.tsx
+++ b/components/SetProgramIdInput.tsx
@@ -5,12 +5,9 @@ import { Button } from "./ui/button";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { isPublickey } from "@/lib/isPublickey";
-import { isProgram } from "@/lib/isProgram";
 
 const SetProgramIdInput = () => {
-  const [programId, setProgramId] = useState(
-    "SQDS4ep65T869zMMBKyuUq6aD6EgTu8psMjkvj52pCf"
-  );
+  const [programId, setProgramId] = useState("");
   const router = useRouter();
 
   const publicKeyTest = isPublickey(programId);

--- a/components/SetProgramIdInput.tsx
+++ b/components/SetProgramIdInput.tsx
@@ -1,0 +1,58 @@
+"use client";
+import { useState } from "react";
+import { Input } from "./ui/input";
+import { Button } from "./ui/button";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { isPublickey } from "@/lib/isPublickey";
+import { isProgram } from "@/lib/isProgram";
+
+const SetProgramIdInput = () => {
+  const [programId, setProgramId] = useState(
+    "SQDS4ep65T869zMMBKyuUq6aD6EgTu8psMjkvj52pCf"
+  );
+  const router = useRouter();
+
+  const publicKeyTest = isPublickey(programId);
+
+  const onSubmit = async () => {
+    // Needs to use an RPC that isn't the public endpoint
+    // const programTest = await isProgram(programId);
+    if (publicKeyTest) {
+      document.cookie = `x-program-id=${programId}`;
+      setProgramId("");
+      router.refresh();
+    } else {
+      throw "Please enter a valid program.";
+    }
+  };
+
+  return (
+    <div>
+      <Input
+        onChange={(e) => setProgramId(e.target.value)}
+        placeholder="SQDS4ep65T869zMMBKyuUq6aD6EgTu8psMjkvj52pCf"
+        defaultValue={programId}
+        className=""
+      />
+      {!publicKeyTest && programId.length > 0 && (
+        <p className="text-xs mt-2 text-red-500">Please enter a valid key.</p>
+      )}
+      <Button
+        onClick={() =>
+          toast.promise(onSubmit(), {
+            loading: "Loading...",
+            success: "Program ID set successfully.",
+            error: (err) => `${err}`,
+          })
+        }
+        disabled={!publicKeyTest && programId.length > 0}
+        className="mt-2"
+      >
+        Set Program ID
+      </Button>
+    </div>
+  );
+};
+
+export default SetProgramIdInput;

--- a/components/TokenList.tsx
+++ b/components/TokenList.tsx
@@ -1,6 +1,6 @@
-import * as multisig from "@sqds/multisig";
 import {
   AccountInfo,
+  LAMPORTS_PER_SOL,
   ParsedAccountData,
   PublicKey,
   RpcResponseAndContext,
@@ -13,8 +13,10 @@ import {
   CardTitle,
 } from "./ui/card";
 import SendTokens from "./SendTokensButton";
+import SendSol from "./SendSolButton";
 
 type TokenListProps = {
+  solBalance: number;
   tokens: RpcResponseAndContext<
     {
       pubkey: PublicKey;
@@ -28,6 +30,7 @@ type TokenListProps = {
 };
 
 export function TokenList({
+  solBalance,
   tokens,
   rpcUrl,
   multisigPda,
@@ -42,6 +45,25 @@ export function TokenList({
       </CardHeader>
       <CardContent>
         <div className="space-y-8">
+          <div>
+            <div className="flex items-center">
+              <div className="ml-4 space-y-1">
+                <p className="text-sm font-medium leading-none">SOL</p>
+                <p className="text-sm text-muted-foreground">
+                  Amount: {solBalance / LAMPORTS_PER_SOL}
+                </p>
+              </div>
+              <div className="ml-auto">
+                <SendSol
+                  rpcUrl={rpcUrl}
+                  multisigPda={multisigPda}
+                  vaultIndex={vaultIndex}
+                  programId={programId}
+                />
+              </div>
+            </div>
+            {tokens.value.length > 0 ? <hr className="mt-2" /> : null}
+          </div>
           {tokens.value.map((token) => (
             <div key={token.account.data.parsed.info.mint}>
               <div className="flex items-center">

--- a/components/TokenList.tsx
+++ b/components/TokenList.tsx
@@ -1,3 +1,4 @@
+import * as multisig from "@sqds/multisig";
 import {
   AccountInfo,
   ParsedAccountData,
@@ -23,6 +24,7 @@ type TokenListProps = {
   rpcUrl: string;
   multisigPda: string;
   vaultIndex: number;
+  programId?: string;
 };
 
 export function TokenList({
@@ -30,6 +32,7 @@ export function TokenList({
   rpcUrl,
   multisigPda,
   vaultIndex,
+  programId,
 }: TokenListProps) {
   return (
     <Card>
@@ -61,6 +64,7 @@ export function TokenList({
                     rpcUrl={rpcUrl}
                     multisigPda={multisigPda}
                     vaultIndex={vaultIndex}
+                    programId={programId}
                   />
                 </div>
               </div>

--- a/components/VaultDisplayer.tsx
+++ b/components/VaultDisplayer.tsx
@@ -1,33 +1,23 @@
 import * as multisig from "@sqds/multisig";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "./ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
 import { PublicKey } from "@solana/web3.js";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "./ui/select";
 import { VaultSelector } from "./VaultSelector";
 
 type VaultDisplayerProps = {
   multisigPdaString: string;
   vaultIndex: number;
+  programId?: string;
 };
 
 export function VaultDisplayer({
   multisigPdaString,
   vaultIndex,
+  programId,
 }: VaultDisplayerProps) {
   const vaultAddress = multisig.getVaultPda({
     multisigPda: new PublicKey(multisigPdaString),
     index: vaultIndex,
+    programId: programId ? new PublicKey(programId) : multisig.PROGRAM_ID,
   });
 
   return (

--- a/components/VaultSelector.tsx
+++ b/components/VaultSelector.tsx
@@ -30,7 +30,6 @@ export function VaultSelector() {
 
   const router = useRouter();
 
-  // useEffect hook to trigger an action when value changes
   React.useEffect(() => {
     document.cookie = `x-vault-index=${value}; path=/`;
     router.refresh();

--- a/components/Wallet.tsx
+++ b/components/Wallet.tsx
@@ -5,11 +5,7 @@ import {
   WalletProvider,
 } from "@solana/wallet-adapter-react";
 import { WalletAdapterNetwork } from "@solana/wallet-adapter-base";
-import {
-  WalletModalProvider,
-  WalletDisconnectButton,
-  WalletMultiButton,
-} from "@solana/wallet-adapter-react-ui";
+import { WalletModalProvider } from "@solana/wallet-adapter-react-ui";
 import { clusterApiUrl } from "@solana/web3.js";
 
 require("@solana/wallet-adapter-react-ui/styles.css");

--- a/lib/isProgram.ts
+++ b/lib/isProgram.ts
@@ -1,0 +1,23 @@
+"use client";
+import { Connection, PublicKey, clusterApiUrl } from "@solana/web3.js";
+
+export async function isProgram(key: string, rpcUrl?: string) {
+  const connection = new Connection(rpcUrl || clusterApiUrl("mainnet-beta"), {
+    commitment: "confirmed",
+  });
+  try {
+    const pk = new PublicKey(key);
+    const info = await connection.getAccountInfo(pk);
+    if (info == null) {
+      return false;
+    } else {
+      if (info.executable) {
+        return true;
+      }
+
+      return false;
+    }
+  } catch (err) {
+    return false;
+  }
+}

--- a/lib/isPublickey.ts
+++ b/lib/isPublickey.ts
@@ -1,0 +1,16 @@
+"use client";
+import { PublicKey } from "@solana/web3.js";
+
+export function isPublickey(key: string) {
+  try {
+    const pk = new PublicKey(key);
+    if (pk) {
+      return true;
+    } else {
+      console.log("Invalid public key");
+      return false;
+    }
+  } catch (err) {
+    return false;
+  }
+}


### PR DESCRIPTION
This PR adds the ability to specify a custom Program ID to use in the UI. This is intended for testing with a staging program on Solana mainnet, testnet, devnet, or other L2s Squads is deployed on. Additionally, this also adds the following miscellaneous changes:

- Better loading state handling
- Handling for the execution of both vault and config transactions
- Surface SOL balance of the current vault, with ability to propose a transaction to send
- Use v0 transactions where beneficial
- Bundle a proposal creation and approval when creating a vault or config transaction
- Simplify various components