### PR TITLE
fix(tx): handle generic messages as input

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -121,6 +121,8 @@ const AppLayout = async ({ children }: { children: React.ReactNode }) => {
         <RenderMultisigRoute multisig={multisig} children={children} />
       </div>
       <Toaster
+        expand
+        visibleToasts={3}
         icons={{
           error: <AlertTriangle className="w-4 h-4 text-red-600" />,
           success: <CheckSquare className="w-4 h-4 text-green-600" />,

--- a/components/CreateTransactionButton.tsx
+++ b/components/CreateTransactionButton.tsx
@@ -17,7 +17,6 @@ import {
   Message,
   PublicKey,
   TransactionInstruction,
-  TransactionMessage,
   clusterApiUrl,
 } from "@solana/web3.js";
 import { Input } from "./ui/input";
@@ -101,17 +100,22 @@ const CreateTransaction = ({
         />
         <div className="flex gap-2 items-center justify-end">
           <Button
-            onClick={() =>
+            onClick={() => {
+              toast("Note: Simulations may fail on alt-SVM", {
+                description: "Please verify via an explorer before submitting.",
+              });
               toast.promise(
                 simulateEncodedTransaction(tx, connection, wallet),
                 {
                   id: "simulation",
                   loading: "Building simulation...",
                   success: "Simulation successful.",
-                  error: (e) => `${e}`,
+                  error: (e) => {
+                    return `${e}`;
+                  },
                 }
-              )
-            }
+              );
+            }}
           >
             Simulate
           </Button>

--- a/components/CreateTransactionButton.tsx
+++ b/components/CreateTransactionButton.tsx
@@ -14,6 +14,7 @@ import * as multisig from "@sqds/multisig";
 import { useWallet } from "@solana/wallet-adapter-react";
 import {
   Connection,
+  Message,
   PublicKey,
   TransactionInstruction,
   TransactionMessage,
@@ -54,7 +55,7 @@ const CreateTransaction = ({
       programId: programId ? new PublicKey(programId) : multisig.PROGRAM_ID,
     })[0];
 
-    const dummyMessage = new TransactionMessage({
+    const dummyMessage = Message.compile({
       instructions: [
         new TransactionInstruction({
           keys: [
@@ -72,7 +73,7 @@ const CreateTransaction = ({
       ],
       payerKey: vaultAddress,
       recentBlockhash: (await connection.getLatestBlockhash()).blockhash,
-    }).compileToLegacyMessage();
+    });
 
     const encoded = bs58.default.encode(dummyMessage.serialize());
 

--- a/lib/transaction/decodeAndDeserialize.ts
+++ b/lib/transaction/decodeAndDeserialize.ts
@@ -1,5 +1,5 @@
 import * as bs58 from "bs58";
-import { VersionedMessage } from "@solana/web3.js";
+import { Message, TransactionMessage, VersionedMessage } from "@solana/web3.js";
 
 export function decodeAndDeserialize(tx: string): {
   message: VersionedMessage;
@@ -8,7 +8,15 @@ export function decodeAndDeserialize(tx: string): {
   try {
     const messageBytes = bs58.default.decode(tx);
     const version = VersionedMessage.deserializeMessageVersion(messageBytes);
-    const message = VersionedMessage.deserialize(messageBytes);
+
+    let message;
+    if (version === "legacy") {
+      let legMsg = Message.from(messageBytes);
+      let converted = TransactionMessage.decompile(legMsg).compileToV0Message();
+      message = VersionedMessage.deserialize(converted.serialize());
+    } else {
+      message = VersionedMessage.deserialize(messageBytes);
+    }
 
     return { version, message };
   } catch (error) {

--- a/lib/transaction/decodeAndDeserialize.ts
+++ b/lib/transaction/decodeAndDeserialize.ts
@@ -1,26 +1,66 @@
 import * as bs58 from "bs58";
-import { Message, TransactionMessage, VersionedMessage } from "@solana/web3.js";
+import {
+  Message,
+  MessageAccountKeys,
+  MessageV0,
+  PublicKey,
+  Transaction,
+  TransactionMessage,
+  VersionedMessage,
+  VersionedTransaction,
+} from "@solana/web3.js";
 
-export function decodeAndDeserialize(tx: string): {
-  message: VersionedMessage;
+interface DeserializedTransaction {
+  message: TransactionMessage;
   version: number | "legacy";
-} {
+  accountKeys: PublicKey[];
+}
+
+/**
+ * Decodes a base58 encoded transaction and deserializes it into a TransactionMessage
+ * @param tx - Base58 encoded transaction string
+ * @returns Object containing the deserialized message, version, and account keys
+ * @throws Error if deserialization fails
+ */
+export function decodeAndDeserialize(tx: string): DeserializedTransaction {
+  if (!tx) {
+    throw new Error("Transaction string is required");
+  }
+
   try {
     const messageBytes = bs58.default.decode(tx);
     const version = VersionedMessage.deserializeMessageVersion(messageBytes);
+    let message: TransactionMessage;
+    let accountKeys: PublicKey[];
 
-    let message;
     if (version === "legacy") {
-      let legMsg = Message.from(messageBytes);
-      let converted = TransactionMessage.decompile(legMsg).compileToV0Message();
-      message = VersionedMessage.deserialize(converted.serialize());
+      const legacyMessage = Message.from(messageBytes);
+      accountKeys = legacyMessage.accountKeys;
+
+      const intermediate = VersionedMessage.deserialize(
+        new MessageV0(legacyMessage).serialize()
+      );
+      message = TransactionMessage.decompile(intermediate, {
+        addressLookupTableAccounts: [],
+      });
     } else {
-      message = VersionedMessage.deserialize(messageBytes);
+      const versionedMessage = VersionedMessage.deserialize(messageBytes);
+      accountKeys = versionedMessage.staticAccountKeys;
+
+      message = TransactionMessage.decompile(versionedMessage, {
+        addressLookupTableAccounts: [],
+      });
     }
 
-    return { version, message };
+    return {
+      version,
+      message,
+      accountKeys,
+    };
   } catch (error) {
-    console.error(error);
-    throw new Error("Failed to decode transaction.");
+    if (error instanceof Error) {
+      throw new Error(`Failed to decode transaction: ${error.message}`);
+    }
+    throw new Error("Failed to decode transaction: Unknown error");
   }
 }

--- a/lib/transaction/getAccountsForSimulation.ts
+++ b/lib/transaction/getAccountsForSimulation.ts
@@ -26,9 +26,12 @@ export async function getAccountsForSimulation(
     const { staticAccountKeys, accountKeysFromLookups } =
       tx.message.getAccountKeys({ addressLookupTableAccounts });
 
-    const staticAddresses = staticAccountKeys
-      .filter((k) => !k.equals(SystemProgram.programId))
-      .map((k) => k.toString());
+    const staticAddresses = staticAccountKeys.reduce((acc, k) => {
+      if (!k.equals(SystemProgram.programId)) {
+        acc.push(k.toString());
+      }
+      return acc;
+    }, [] as string[]);
 
     const addressesFromLookups = accountKeysFromLookups
       ? accountKeysFromLookups.writable.map((k) => k.toString())

--- a/lib/transaction/getAccountsForSimulation.ts
+++ b/lib/transaction/getAccountsForSimulation.ts
@@ -26,7 +26,9 @@ export async function getAccountsForSimulation(
     const { staticAccountKeys, accountKeysFromLookups } =
       tx.message.getAccountKeys({ addressLookupTableAccounts });
 
-    const staticAddresses = staticAccountKeys.map((k) => k.toString());
+    const staticAddresses = staticAccountKeys
+      .filter((k) => !k.equals(SystemProgram.programId))
+      .map((k) => k.toString());
 
     const addressesFromLookups = accountKeysFromLookups
       ? accountKeysFromLookups.writable.map((k) => k.toString())

--- a/lib/transaction/importTransaction.ts
+++ b/lib/transaction/importTransaction.ts
@@ -3,6 +3,7 @@ import {
   Connection,
   PublicKey,
   TransactionMessage,
+  VersionedMessage,
   VersionedTransaction,
 } from "@solana/web3.js";
 import { decodeAndDeserialize } from "./decodeAndDeserialize";
@@ -29,7 +30,7 @@ export const importTransaction = async (
       new PublicKey(multisigPda)
     );
 
-    const transactionMessage = TransactionMessage.decompile(message);
+    const transactionMessage = new TransactionMessage(message);
 
     const addressLookupTableAccounts =
       version === 0

--- a/lib/transaction/simulateEncodedTransaction.ts
+++ b/lib/transaction/simulateEncodedTransaction.ts
@@ -20,7 +20,7 @@ export const simulateEncodedTransaction = async (
     const keys = await getAccountsForSimulation(
       connection,
       transaction,
-      version === "legacy"
+      version === 0
     );
 
     toast.loading("Simulating...", {

--- a/lib/transaction/simulateEncodedTransaction.ts
+++ b/lib/transaction/simulateEncodedTransaction.ts
@@ -15,7 +15,7 @@ export const simulateEncodedTransaction = async (
   try {
     const { message, version } = decodeAndDeserialize(tx);
 
-    const transaction = new VersionedTransaction(message);
+    const transaction = new VersionedTransaction(message.compileToV0Message());
 
     const keys = await getAccountsForSimulation(
       connection,


### PR DESCRIPTION
This adds some additional handling for message deserialization in the case that a user is inputting a base58 serialized `Message`, rather than a `TransactionMessage` or `VersionedMessage`